### PR TITLE
Фикс вечноломающихся канистр.

### DIFF
--- a/code/modules/atmospheric/machinery/portable/canister.dm
+++ b/code/modules/atmospheric/machinery/portable/canister.dm
@@ -201,7 +201,7 @@ update_flag
 		take_damage(5)
 
 /obj/machinery/portable_atmospherics/canister/proc/take_damage(amount)
-	if((flags & BROKEN) || (flags & NODECONSTRUCT))
+	if((stat & BROKEN) || (flags & NODECONSTRUCT))
 		return
 
 	health = Clamp(health - amount, 0, initial(health))


### PR DESCRIPTION
После того как разрушаешь канистры, они переходят в состояние РАЗРУШЕННЫЙ.
Баг был в том, что канистра каждый удар после этого переходила в разрушенное состояние, то-есть спавнила давление.

:cl: JamsMor
- bugfix: Канистры разрушаются один раз и навсегда.
