### PR TITLE
Дегрифизация фороновых построек

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -970,11 +970,6 @@ var/list/airlock_overlays = list()
 		..()
 	return
 
-/obj/machinery/door/airlock/phoron/attackby(C, mob/user)
-	if(C)
-		ignite(is_hot(C))
-	..()
-
 /obj/machinery/door/airlock/proc/close_unsafe(bolt_after = FALSE)
 	var/temp = safe
 

--- a/code/game/machinery/doors/airlock_types.dm
+++ b/code/game/machinery/doors/airlock_types.dm
@@ -145,33 +145,6 @@
 	icon = 'icons/obj/doors/airlocks/station/phoron.dmi'
 	mineral = "phoron"
 
-/obj/machinery/door/airlock/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > 300)
-		PhoronBurn(exposed_temperature)
-
-/obj/machinery/door/airlock/phoron/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PhoronBurn(exposed_temperature)
-
-/obj/machinery/door/airlock/phoron/proc/PhoronBurn(temperature)
-	for(var/turf/simulated/floor/target_tile in range(2, loc))
-		target_tile.assume_gas("phoron", 35, 400 + T0C)
-		INVOKE_ASYNC(target_tile, /turf/simulated/floor.proc/hotspot_expose, temperature, 400)
-
-	for(var/obj/structure/falsewall/phoron/F in range(3, src))//Hackish as fuck, but until temperature_expose works, there is nothing I can do -Sieve
-		var/turf/T = get_turf(F)
-		T.ChangeTurf(/turf/simulated/wall/mineral/phoron/)
-		qdel(F)
-
-	for(var/turf/simulated/wall/mineral/phoron/W in range(3, src))
-		W.ignite((temperature / 4))//Added so that you can't set off a massive chain reaction with a small flame
-
-	for(var/obj/machinery/door/airlock/phoron/D in range(3, src))
-		D.ignite(temperature / 4)
-
-	new/obj/structure/door_assembly( src.loc )
-	qdel(src)
-
 /obj/machinery/door/airlock/clown
 	name = "bananium airlock"
 	icon = 'icons/obj/doors/airlocks/station/bananium.dmi'

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -223,28 +223,6 @@
 /obj/structure/mineral_door/transparent/phoron
 	mineralType = "phoron"
 
-/obj/structure/mineral_door/transparent/phoron/attackby(obj/item/weapon/W, mob/user)
-	if(istype(W,/obj/item/weapon/weldingtool))
-		var/obj/item/weapon/weldingtool/WT = W
-		if(WT.remove_fuel(0, user))
-			TemperatureAct(100)
-	..()
-
-/obj/structure/mineral_door/transparent/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if(exposed_temperature > 300)
-		TemperatureAct(exposed_temperature)
-
-/obj/structure/mineral_door/transparent/phoron/proc/TemperatureAct(temperature)
-	for(var/turf/simulated/floor/target_tile in range(2,loc))
-
-		var/phoronToDeduce = temperature/10
-
-		target_tile.assume_gas("phoron", phoronToDeduce)
-		target_tile.hotspot_expose(temperature, 400)
-
-		health -= phoronToDeduce/100
-		CheckHealth()
-
 /obj/structure/mineral_door/transparent/diamond
 	mineralType = "diamond"
 	health = 1000

--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -90,45 +90,6 @@
 	mineral = "phoron"
 	sheet_type = /obj/item/stack/sheet/mineral/phoron
 
-/turf/simulated/wall/mineral/phoron/attackby(obj/item/weapon/W, mob/user)
-	if(is_hot(W) > 300)//If the temperature of the object is over 300, then ignite
-		ignite(is_hot(W))
-		return
-	..()
-
-/turf/simulated/wall/mineral/phoron/proc/PhoronBurn(temperature)
-	spawn(2)
-	new /obj/structure/girder(src)
-	src.ChangeTurf(/turf/simulated/floor)
-	for(var/turf/simulated/floor/target_tile in range(0,src))
-		/*if(target_tile.parent && target_tile.parent.group_processing)
-			target_tile.parent.suspend_group_processing()*/
-		target_tile.assume_gas("phoron", 20)
-		target_tile.hotspot_expose(400 + T0C, 400)
-	for(var/obj/structure/falsewall/phoron/F in range(3,src))//Hackish as fuck, but until temperature_expose works, there is nothing I can do -Sieve
-		var/turf/T = get_turf(F)
-		T.ChangeTurf(/turf/simulated/wall/mineral/phoron/)
-		qdel(F)
-	for(var/turf/simulated/wall/mineral/phoron/W in range(3,src))
-		W.ignite((temperature/4))//Added so that you can't set off a massive chain reaction with a small flame
-	for(var/obj/machinery/door/airlock/phoron/D in range(3,src))
-		D.ignite(temperature/4)
-
-/turf/simulated/wall/mineral/phoron/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air :(
-	if(exposed_temperature > 300)
-		PhoronBurn(exposed_temperature)
-
-/turf/simulated/wall/mineral/phoron/proc/ignite(exposed_temperature)
-	if(exposed_temperature > 300)
-		PhoronBurn(exposed_temperature)
-
-/turf/simulated/wall/mineral/phoron/bullet_act(obj/item/projectile/Proj)
-	if(istype(Proj,/obj/item/projectile/beam))
-		PhoronBurn(2500)
-	else if(istype(Proj,/obj/item/projectile/ion))
-		PhoronBurn(500)
-	..()
-
 /*
 /turf/simulated/wall/mineral/proc/shock()
 	if (electrocute_mob(user, C, src))

--- a/code/modules/atmospheric/xgm/gases.dm
+++ b/code/modules/atmospheric/xgm/gases.dm
@@ -31,7 +31,7 @@
 	//and following a N/Z ratio of 1.5, the molar mass of a monatomic gas is:
 	molar_mass = 0.405	// kg/mol
 
-	tile_overlay = "phoron"
+	tile_overlay = "plasma-purple"
 	overlay_limit = 0.7
 	flags = XGM_GAS_FUEL | XGM_GAS_CONTAMINANT | XGM_GAS_FUSION_FUEL
 	dangerous = TRUE


### PR DESCRIPTION
Выпилены к такой-то материи взаимодействия указанных строений, в свете недавних ВЗРЫВНЫХ событий. 
:cl:
 - tweak: Строения из форона теперь не заливают всё адским пламенем, при возгорании.
 - tweak: Газообразный форон теперь правильного, фиолетового цвета.

