### PR TITLE
Радшторм не затрагивает СПУ

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -175,7 +175,7 @@
 	if(prob(40))
 		if(ishuman(L))
 			var/mob/living/carbon/human/H = L
-			if(H.dna && H.dna.species)
+			if(H.dna && H.dna.species && !H.species.flags[IS_SYNTHETIC])
 				if(prob(max(0,100-resist)) && prob(10))
 					if (prob(75))
 						randmutb(H) // Applies bad mutation


### PR DESCRIPTION
Fixes #80 

Воткнул первый попавшийся костыль
:cl:
 - bugfix: СПУ более не мутируют при радиационном шторме

