### PR TITLE
Запрет на использование ряда предметов живностью

### DIFF
--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -37,6 +37,10 @@
 /obj/item/device/flash/attack(mob/living/M, mob/user)
 	if(!user || !M)	return	//sanity
 
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='red'>You don't have the dexterity to do this!</span>")
+		return
+
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been flashed (attempt) with [src.name]  by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [src.name] to flash [M.name] ([M.ckey])</font>")
 	msg_admin_attack("[user.name] ([user.ckey]) Used the [src.name] to flash [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
@@ -129,7 +133,7 @@
 
 
 /obj/item/device/flash/attack_self(mob/living/carbon/user, flag = 0, emp = 0)
-	if(!user || !clown_check(user)) 	return
+	if(!user || !clown_check(user) || !user.IsAdvancedToolUser()) 	return
 	if(broken)
 		user.show_message("<span class='warning'>The [src.name] is broken</span>", 2)
 		return

--- a/code/game/objects/items/devices/remote_device.dm
+++ b/code/game/objects/items/devices/remote_device.dm
@@ -32,6 +32,9 @@
 		to_chat(user, "This device now can electrify doors")
 
 /obj/item/device/remote_device/attack_self(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='red'>You don't have the dexterity to do this!</span>")
+		return
 	if(mode == REMOTE_OPEN)
 		if(emagged)
 			mode = REMOTE_ELECT
@@ -45,7 +48,7 @@
 	to_chat(user, "Now in mode: [mode].")
 
 /obj/item/device/remote_device/afterattack(obj/machinery/door/airlock/D, mob/user)
-	if(!istype(D) || disabled || user.client.eye != user.client.mob)
+	if(!istype(D) || disabled || user.client.eye != user.client.mob || !user.IsAdvancedToolUser())
 		return
 	if(!D.hasPower())
 		to_chat(user, "<span class='danger'>[D] has no power!</span>")

--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -136,6 +136,9 @@ Frequency:
 	origin_tech = "magnets=1;bluespace=3"
 
 /obj/item/weapon/hand_tele/attack_self(mob/user)
+	if(!user.IsAdvancedToolUser())
+		to_chat(user, "<span class='red'>You don't have the dexterity to do this!</span>")
+		return
 	var/turf/current_location = get_turf(user)//What turf is the user on?
 	if(!current_location||current_location.z==2||current_location.z>=7)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
 		to_chat(user, "<span class='notice'>\The [src] is malfunctioning.</span>")


### PR DESCRIPTION
Closes #52 
Добавил проверку на AdvancedToolUser флешкам, пультам от дверей и ханд теле, чтобы ети ваши грифозные макаки с псинами не грифонили ими. Собственно, ПР далеко не полный, нужно искать такие предметы и устройства дальше и впиливать им эту проверку.

:cl:
 - tweak: Ослепители, пульты от дверей и портативные телепортеры теперь недоступны для использования обезьянам, собакам и прочей живности
