### PR TITLE
Картечь снова работает

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -63,7 +63,7 @@
 		P.def_zone = check_zone(chassis.occupant.zone_sel.selecting)
 	P.yo = aimloc.y - P.loc.y
 	P.xo = aimloc.x - P.loc.x
-	P.process()
+	P.process(aimloc)
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy
 	name = "General Energy Weapon"

--- a/code/modules/projectiles/firing.dm
+++ b/code/modules/projectiles/firing.dm
@@ -46,7 +46,7 @@
 		if(mouse_control["icon-y"])
 			BB.p_y = text2num(mouse_control["icon-y"])
 	if(BB)
-		BB.process()
+		BB.process(targloc)
 	BB = null
 	return 1
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -249,9 +249,10 @@
 		return 1
 
 
-/obj/item/projectile/process()
+/obj/item/projectile/process(turf/fintargloc)
 	var/first_step = 1
-
+	if(fintargloc)
+		original = fintargloc
 	//plot the initial trajectory
 	setup_trajectory()
 


### PR DESCRIPTION
Крайне раздражающий баг, созданный одними дебилами и упорно отрицаемый другими долбоёбами с 2015 года. 

Реализация фикса малость сомнительная, и походу ещё где-то аукнется, так что будем смотреть, но прогресс, как грится, налицо. Также имеется небольшой визуальный косяк, заключающийся в отрисовке эффекта выстрела для каждой пульки отдельно, но тут надо уже перепиливать эту систему с привязкой к патрону/пушке, а не пуле. 

Теперь комбат шотганы и маулеры грейт эгейн. 

:cl:
 - bugfix: Восстановлен разлёт картечи у дробовиков
