### PR TITLE
Исправлено логирование проджектайлов

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -36,7 +36,6 @@
 			visible_message("<span class='userdanger'>The [P.name] hits [src]'s armor!</span>")
 			P.agony /= 2
 		apply_effect(P.agony,AGONY,0)
-		qdel(P)
 		if(istype(wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/V = wear_suit
 			V.attack_reaction(src, REACTION_HIT_BY_BULLET)
@@ -57,7 +56,6 @@
 		P.on_hit(src)
 		flash_pain()
 		to_chat(src, "<span class='userdanger'>You have been shot!</span>")
-		qdel(P)
 		if(istype(wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/V = wear_suit
 			V.attack_reaction(src, REACTION_HIT_BY_BULLET)
@@ -74,7 +72,6 @@
 				if(C.body_parts_covered & BP.body_part) // Is that body part being targeted covered?
 					if(C.flags & THICKMATERIAL )
 						visible_message("<span class='userdanger'> <B>The [P.name] gets absorbed by [src]'s [C.name]!</span>")
-						qdel(P)
 						return
 
 		BP = bodyparts_by_name[check_zone(def_zone)]
@@ -83,7 +80,6 @@
 		apply_effects(P.stun,P.weaken,0,0,P.stutter,0,0,armorblock)
 		flash_pain()
 		to_chat(src, "<span class='userdanger'>You have been shot!</span>")
-		qdel(P)
 		if(istype(wear_suit, /obj/item/clothing/suit))
 			var/obj/item/clothing/suit/V = wear_suit
 			V.attack_reaction(src, REACTION_HIT_BY_BULLET)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -123,7 +123,7 @@
 				miss_chance = 60
 		if(prob(max(miss_chance + miss_chance_mod, 0)))
 			if(prob(max(20, (miss_chance/2))))
-				return null
+				return 0
 			else
 				var/t = rand(1, 100)
 				switch(t)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -197,7 +197,7 @@
 		forcedodge = A.bullet_act(src, def_zone) // searches for return value
 
 		if(M)
-			add_logs(M,silenced,forcedodge,F)
+			add_logs(M,forcedodge,F)
 
 	if(forcedodge == PROJECTILE_FORCE_MISS) // the bullet passes through a dense object!
 		if(M)
@@ -226,7 +226,7 @@
 	qdel(src)
 	return 1
 
-/obj/item/projectile/proc/add_logs(mob/M, silenced=0, forcedodge,mob/firer)
+/obj/item/projectile/proc/add_logs(mob/M, forcedodge,mob/firer)
 	if(silenced)
 		to_chat(M, "<span class='userdanger'>You've been shot in the [parse_zone(def_zone)] by the [src.name]!</span>")
 	else

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -167,7 +167,6 @@
 
 	var/forcedodge = 0 // force the projectile to pass
 	var/mob/M = ismob(A) ? A : null
-	var/mob/F = firer
 	bumped = 1
 	if(firer && M)
 		if(!istype(A, /mob/living))
@@ -193,16 +192,15 @@
 		if(M && ishuman(M))
 			M = check_living_shield(A)
 			A = M
-
 		forcedodge = A.bullet_act(src, def_zone) // searches for return value
 
 		if(M)
-			add_logs(M,forcedodge,F)
+			add_logs(M,0)
 
 	if(forcedodge == PROJECTILE_FORCE_MISS) // the bullet passes through a dense object!
 		if(M)
 			visible_message("<span class = 'notice'>\The [src] misses [M] narrowly!</span>")
-
+			add_logs(M,1)
 		if(istype(A, /turf))
 			loc = A
 		else
@@ -226,14 +224,14 @@
 	qdel(src)
 	return 1
 
-/obj/item/projectile/proc/add_logs(mob/M, forcedodge,mob/firer)
+/obj/item/projectile/proc/add_logs(mob/M, miss)
 	if(silenced)
 		to_chat(M, "<span class='userdanger'>You've been shot in the [parse_zone(def_zone)] by the [src.name]!</span>")
 	else
 		M.visible_message("<span class='userdanger'>[M.name] is hit by the [src.name] in the [parse_zone(def_zone)]!</span>")
 
 	if(firer)
-		if(forcedodge == PROJECTILE_FORCE_MISS)
+		if(miss)
 			M.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> tried to shot <b>[M]/[M.ckey]</b> with a <b>[src.type] but MISSED</b>"
 			firer.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> tried to shot <b>[M]/[M.ckey]</b> with a <b>[src.type] but MISSED</b>"
 			if(!fake)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -167,6 +167,7 @@
 
 	var/forcedodge = 0 // force the projectile to pass
 	var/mob/M = ismob(A) ? A : null
+	var/mob/F = firer
 	bumped = 1
 	if(firer && M)
 		if(!istype(A, /mob/living))
@@ -195,6 +196,9 @@
 
 		forcedodge = A.bullet_act(src, def_zone) // searches for return value
 
+		if(M)
+			add_logs(M,silenced,forcedodge,F)
+
 	if(forcedodge == PROJECTILE_FORCE_MISS) // the bullet passes through a dense object!
 		if(M)
 			visible_message("<span class = 'notice'>\The [src] misses [M] narrowly!</span>")
@@ -207,23 +211,6 @@
 		permutated.Add(A)
 
 		return FALSE
-
-	else if(M)
-		if(silenced)
-			to_chat(M, "<span class='userdanger'>You've been shot in the [parse_zone(def_zone)] by the [src.name]!</span>")
-		else
-			M.visible_message("<span class='userdanger'>[M.name] is hit by the [src.name] in the [parse_zone(def_zone)]!</span>")
-			//X has fired Y is now given by the guns so you cant tell who shot you if you could not see the shooter
-		if(firer)
-			M.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src.type]</b>"
-			firer.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src.type]</b>"
-			if(!fake)
-				msg_admin_attack("[firer.name] ([firer.ckey]) shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(firer)] [ADMIN_FLW(firer)]") //BS12 EDIT ALG
-		else
-			M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
-			if(!fake)
-				msg_admin_attack("UNKNOWN shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(M)] [ADMIN_FLW(M)]") //BS12 EDIT ALG
-
 
 	if(istype(A,/turf))
 		for(var/obj/O in A)
@@ -239,6 +226,27 @@
 	qdel(src)
 	return 1
 
+/obj/item/projectile/proc/add_logs(mob/M, silenced=0, forcedodge,mob/firer)
+	if(silenced)
+		to_chat(M, "<span class='userdanger'>You've been shot in the [parse_zone(def_zone)] by the [src.name]!</span>")
+	else
+		M.visible_message("<span class='userdanger'>[M.name] is hit by the [src.name] in the [parse_zone(def_zone)]!</span>")
+
+	if(firer)
+		if(forcedodge == PROJECTILE_FORCE_MISS)
+			M.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> tried to shot <b>[M]/[M.ckey]</b> with a <b>[src.type] but MISSED</b>"
+			firer.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> tried to shot <b>[M]/[M.ckey]</b> with a <b>[src.type] but MISSED</b>"
+			if(!fake)
+				msg_admin_attack("[firer.name] ([firer.ckey]) tried shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(firer)] [ADMIN_FLW(firer)] but MISSED")
+		else
+			M.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src.type]</b>"
+			firer.attack_log += "\[[time_stamp()]\] <b>[firer]/[firer.ckey]</b> shot <b>[M]/[M.ckey]</b> with a <b>[src.type]</b>"
+			if(!fake)
+				msg_admin_attack("[firer.name] ([firer.ckey]) shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(firer)] [ADMIN_FLW(firer)]")
+	else
+		M.attack_log += "\[[time_stamp()]\] <b>UNKNOWN SUBJECT</b> shot <b>[M]/[M.ckey]</b> with a <b>[src]</b>"
+		if(!fake)
+			msg_admin_attack("UNKNOWN shot [M.name] ([M.ckey]) with a [src] [ADMIN_JMP(M)] [ADMIN_FLW(M)]")
 
 /obj/item/projectile/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0)) return 1


### PR DESCRIPTION
Продолжаем бороться с тяжёлым наследием топовых реFUCKторщиков таукекии, на этот раз, отмываем от следов известной субстанции логи всеми любимых пулек, суём их в отдельную процедуру и посыпаем костыликами, а всё ради чего:
- исправляем недочёт, когда целишься в отсутствующую конечность, пуля пролетает, а в лог пишется что попал - теперь в логе будет поправка. ~~Так как по моим данным, бывают исключительно в этом случае, фикс сделан под них - если промахи при других ситуациях вернутся, то надо будет и логи подшаманить, но это тема другого разговора~~ 
**Промахи таки существуют, поэтому логи учитывают и их. Пришлось исправить один null на конкретный 0.** 
~~- делаем копию ссылки на стреляющего, так как оригинал проёбывается в неизвестном направлении, теперь имя виновника будет отображено~~, если он конечно не симпл моб, там останется UNKNOWN, но это опять же, тема для перепила стреляющих мобов 
**Теперь костыль не нужен, так как суть проблемы крылась в древних куделях в коде буллет_акта людей, которые были расстреляны (вот ето каламбур)**

:cl:
 - bugfix: Исправлено логирование пуль и снарядов
