### PR TITLE
Предметы из голодека теперь не вынести в оберточной бумаге

### DIFF
--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -220,10 +220,11 @@
 		return
 
 	if(isobj(obj))
-		var/mob/M = obj.loc
-		if(ismob(M))
-			M.remove_from_mob(obj)
-			M.update_icons()	//so their overlays update
+		var/turf/T = get_turf(obj)
+		for(var/atom/movable/AM in obj) // these should be derezed if they were generated
+			AM.forceMove(T)
+			if(ismob(AM))
+				silent = FALSE
 
 	if(!silent)
 		var/obj/oldobj = obj


### PR DESCRIPTION
Воспользовался вариантом с TG

:cl:
 - bugfix: Предметы с голодека более нельзя вынести в упаковочной бумаге.
