### PR TITLE
Упаковочная бумага игнорирует предметы из голодека

### DIFF
--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -140,6 +140,8 @@
 			else
 				if(istype(W, /obj/item/smallDelivery) || istype(W, /obj/item/weapon/gift)) //No gift wrapping gifts!
 					return
+				if(W.flags_2 & HOLOGRAM_2)
+					return
 
 				src.amount -= a_used
 				user.drop_item()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -102,6 +102,8 @@
 	if(istype(target, /obj/item/smallDelivery) || istype(target,/obj/structure/bigDelivery) \
 	|| istype(target, /obj/item/weapon/gift) || istype(target, /obj/item/weapon/evidencebag))
 		return
+	if(target.flags_2 & HOLOGRAM_2)
+		return
 	if(target.anchored)
 		return
 	if(target in user)


### PR DESCRIPTION
NO MORE

собственно суть заключается в добавлении упаковке новой проверки
:cl:
 - bugfix: Теперь невозможно вынести с голодека предметы с помощью обёрточной бумаги
