### PR TITLE
Changeling stasis fix

### DIFF
--- a/code/game/gamemodes/changeling/headcrab.dm
+++ b/code/game/gamemodes/changeling/headcrab.dm
@@ -22,6 +22,15 @@
 		S.Weaken(3)
 
 	var/mob/living/simple_animal/headcrab/crab = new(get_turf(user))
+
+	var/obj/effect/proc_holder/changeling/revive/R = locate() in M.changeling.purchasedpowers		//Prevents having Regenerate verb after rebirth
+	if(R)
+		M.changeling.purchasedpowers -= R
+
+	if(M.changeling.instatis)
+		M.changeling.instatis = FALSE		//In case we did it out of stasis
+		user.fake_death = FALSE
+
 	crab.origin = M
 	M.transfer_to(crab)
 	for(var/mob/living/parasite/essence/E in user)

--- a/code/game/gamemodes/changeling/powers/revive.dm
+++ b/code/game/gamemodes/changeling/powers/revive.dm
@@ -30,6 +30,7 @@
 		user.mind.changeling.purchasedpowers -= src //We dont need that power from now anyway.
 		return
 	if(user.stat < 2)//We are alive when using this... Why do we need to keep this ability and even rejuvenate, if revive must used from dead state?
-		to_chat(user, "<span class='notice'>We ready to regenerate, but we need to stop any life activity in our body.</span>")
+		user.mind.changeling.purchasedpowers -= src		//If we somehow acquired it, remove upon clicking, to prevent stasis breaking
+		to_chat(user, "<span class='notice'>We need to stop any life activity in our body.</span>")
 		return
 	return ..()


### PR DESCRIPTION
Фикс стазиса генокрада. Если человек в завершённом стазисе решил вместо вставания из мёртвых использовать Ласт Резорт - у него удаляется Regenerate. Если же он умудрился получить эту подспособность и в то же время остаться в живых, при нажатии она у него удалится.

Пример списка:
:cl:
 - bugfix: Пофикшен стазис у генокрадов
-->
