### PR TITLE
No peka in IC

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -106,7 +106,7 @@ var/list/department_radio_keys = list(
 		if(dongle.translate_binary)
 			return 1
 
-/mob/living/say(message, datum/language/speaking = null, verb="says", alt_name="", italics=FALSE, message_range = world.view, list/used_radios = list(), sound/speech_sound, sound_vol, sanitize = TRUE, message_mode = FALSE)
+/mob/living/say(message, datum/language/speaking = null, verb="says", alt_name="", italics=FALSE, message_range = world.view, list/used_radios = list(), sound/speech_sound, sound_vol, sanitize = TRUE, message_mode = FALSE, memeprotection = TRUE)
 	if (src.client)
 		if(client.prefs.muted & MUTE_IC)
 			to_chat(src, "You cannot send IC messages (muted).")
@@ -116,6 +116,12 @@ var/list/department_radio_keys = list(
 
 	if(sanitize)
 		message = sanitize(message)
+
+	if(memeprotection)
+		var/static/regex/AntiPeka = new/regex(":\[^ ]+:")
+		if(AntiPeka.Find(message))
+			to_chat(src, "<span class='warning'>IC messages containing emojis are forbidden.</span>")
+			return
 
 	var/turf/T = get_turf(src)
 


### PR DESCRIPTION
Всё. Теперь если персонаж попытается при разговоре запостить эмодзи - он кашлянёт, а сообщение не появится. В сэй прок появился ещё один аргумент, на случай если будет сделан моб которому необходимо будет по какой то причине писать пеки в ИЦ.
Пример списка:
:cl:
 - rscdel: Больше нельзя постить эмодзи в ИЦ
