### PR TITLE
Damp rag боьше не чистит одежду на мобе

### DIFF
--- a/code/modules/detectivework/footprints_and_rag.dm
+++ b/code/modules/detectivework/footprints_and_rag.dm
@@ -39,7 +39,9 @@
 /obj/item/weapon/reagent_containers/glass/rag/afterattack(atom/A, mob/user, proximity)
 	if(!proximity) return
 	if(user.is_busy()) return
-	if(istype(A) && src in user)
+	if(user.client && (A in user.client.screen))
+		to_chat(user, "<span class='notice'>You need to take that [A] off before cleaning it.</span>")
+	else if(istype(A) && src in user)
 		user.visible_message("[user] starts to wipe down [A] with [src]!")
 		if(do_after(user,30,target = A))
 			user.visible_message("[user] finishes wiping off the [A]!")


### PR DESCRIPTION
Возможно, грубая копипаста куска кода с мыла, но работает. Чистит вещи ровно как и мыло, разве что с задержкой в 3 секунды.

Раньше при попытке очистить одежду от крови на себе её чистило, но на оверлее куклы это не отображалось, пока не снимешь и наденешь.

:cl: Dred1792
 - tweak: Нельзя чистить вещи damp rag'ом не снимая/держа в руках.
