### PR TITLE
Backpacks & satchels tweaks

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -14,8 +14,10 @@
 	max_w_class = 3
 	max_combined_w_class = 21
 	var/opened = 0
+	cant_reach = TRUE
 
 /obj/item/weapon/storage/backpack/ui_action_click()
+
 	if(!opened)
 		open(loc)
 	else
@@ -30,6 +32,8 @@
 /obj/item/weapon/storage/backpack/equipped(mob/user, slot)
 	if (slot == slot_back && src.use_sound)
 		playsound(src.loc, src.use_sound, 50, 1, -5)
+		if(cant_reach == TRUE)
+			close(user)
 	..(user, slot)
 
 /*
@@ -133,6 +137,8 @@
 	desc = "It's a very fancy satchel made with fine leather."
 	icon_state = "satchel"
 	item_state = "satchel"
+	storage_slots = 4
+	cant_reach = FALSE
 
 /obj/item/weapon/storage/backpack/satchel/withwallet
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -24,6 +24,7 @@
 	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
 	var/foldable = null	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
+	var/cant_reach = FALSE
 
 /obj/item/weapon/storage/Destroy()
 	close_all()
@@ -42,8 +43,12 @@
 			return
 
 		if(over_object == usr && Adjacent(usr)) // this must come before the screen objects only block
-			src.open(usr)
-			return
+			if(istype(src, /obj/item/weapon/storage/backpack) && usr.back == src && cant_reach == TRUE)
+				to_chat(usr, "<span class='warning'>You can't reach into your [name] while it's on your back!</span>")
+				return
+			else
+				open(usr)
+				return
 
 		if (!( istype(over_object, /obj/screen) ))
 			return ..()
@@ -387,6 +392,9 @@
 		if(H.r_store == src && !H.get_active_hand())
 			H.put_in_hands(src)
 			H.r_store = null
+			return
+		if(istype(src, /obj/item/weapon/storage/backpack) && H.back == src && cant_reach == TRUE)
+			to_chat(H, "<span class='warning'>You can't reach into your [name] while it's on your back!</span>")
 			return
 
 	if (src.loc == user)


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->

Теперь рюкзаки нельзя открывать, пока они висят на спине. С сумками как прежде, но у них урезана вместимость до 4 слотов.

:cl:
 - balance: Чтобы взять вещи из рюкзака, его нужно снять со спины. У сумок уменьшена вместимость.
