### PR TITLE
Ещё пачка фиксов для инвентаря

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -75,6 +75,23 @@
 		if(I)
 			master.attackby(I, usr, params)
 			usr.next_move = world.time+2
+			return 1
+
+		var/obj/item/weapon/storage/S = master
+		if(!S || !S.storage_ui)
+			return 1
+		// Taking something out of the storage screen (including clicking on item border overlay)
+		var/list/PM = params2list(params)
+		var/list/screen_loc_params = splittext(PM["screen-loc"], ",")
+		var/list/screen_loc_X = splittext(screen_loc_params[1],":")
+		var/click_x = text2num(screen_loc_X[1])*32+text2num(screen_loc_X[2]) - 144
+
+		for(var/i=1,i<=S.storage_ui.click_border_start.len,i++)
+			if (S.storage_ui.click_border_start[i] <= click_x && click_x <= S.storage_ui.click_border_end[i] && i <= S.contents.len)
+				I = S.contents[i]
+				if (I)
+					I.attack_hand(usr)
+					return 1
 	return 1
 
 /obj/screen/gun

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -123,3 +123,4 @@
 	. = ..()
 	for (var/i in 1 to 7)
 		new /obj/item/mecha_parts/mecha_tracking(src)
+	make_exact_fit()

--- a/code/game/objects/items/devices/radio/beacon.dm
+++ b/code/game/objects/items/devices/radio/beacon.dm
@@ -60,6 +60,7 @@
 /obj/item/weapon/medical/teleporter
 	name = "Body Teleporter"
 	desc = "A device used for teleporting injured(critical) or dead people."
+	w_class = ITEM_SIZE_SMALL
 	gender = PLURAL
 	icon = 'icons/obj/device.dmi'
 	icon_state = "medicon"

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -5,11 +5,17 @@
 	amount = 5
 	max_amount = 5
 	w_class = ITEM_SIZE_TINY
-	full_w_class = ITEM_SIZE_TINY
+	full_w_class = ITEM_SIZE_SMALL
 	throw_speed = 4
 	throw_range = 20
 	var/heal_brute = 0
 	var/heal_burn = 0
+
+/obj/item/stack/medical/update_weight()
+	if(amount < 3)
+		w_class = initial(w_class)
+	else
+		w_class = full_w_class
 
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user, def_zone)
 	if(!istype(M))
@@ -276,6 +282,8 @@
 	icon_state = "splint"
 	amount = 5
 	max_amount = 5
+	w_class = ITEM_SIZE_SMALL
+	full_w_class = ITEM_SIZE_SMALL
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user, def_zone)
 	if(..())

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -562,7 +562,6 @@
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "shotgun_ammo_slug"
 	foldable = /obj/item/stack/sheet/cardboard
-	storage_slots = 16
 	can_hold = list("/obj/item/ammo_casing/shotgun")
 
 
@@ -574,6 +573,7 @@
 	. = ..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun(src)
+	make_exact_fit()
 
 
 /obj/item/weapon/storage/box/shotgun/buckshot
@@ -584,6 +584,7 @@
 	. = ..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/buckshot(src)
+	make_exact_fit()
 
 
 /obj/item/weapon/storage/box/shotgun/beanbag
@@ -594,6 +595,7 @@
 	. = ..()
 	for(var/i in 1 to 16)
 		new /obj/item/ammo_casing/shotgun/beanbag(src)
+	make_exact_fit()
 
 //Hair sprays
 /obj/item/weapon/storage/box/hairdyes

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -429,6 +429,22 @@
 			var/obj/O = A
 			O.hear_talk(M, text, verb, speaking)
 
+/obj/item/weapon/storage/proc/make_exact_fit(use_slots = FALSE)
+	if(use_slots)
+		storage_slots = contents.len
+	else
+		storage_slots = null
+
+	can_hold.Cut()
+	max_w_class = 0
+	max_storage_space = 0
+	for(var/obj/item/I in src)
+		var/texttype = "[I.type]"
+		if(!(texttype in can_hold))
+			can_hold += texttype
+		max_w_class = max(I.w_class, max_w_class)
+		max_storage_space += I.get_storage_cost()
+
 //Returns the storage depth of an atom. This is the number of storage items the atom is contained in before reaching toplevel (the area).
 //Returns -1 if the atom was not found on container.
 /atom/proc/storage_depth(atom/container)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -181,6 +181,8 @@
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/storage_ui/default/proc/slot_orient_objs()
 	var/adjusted_contents = storage.contents.len
+	click_border_start.Cut()
+	click_border_end.Cut()
 
 	//Numbered contents display
 	var/list/datum/numbered_display/numbered_contents
@@ -250,6 +252,8 @@
 	var/stored_cap_width = 4 //length of sprite for start and end of the box representing the stored item
 	var/storage_width = min( round( 224 * storage.max_storage_space/baseline_max_storage_space ,1) ,284) //length of sprite for the box representing total storage space
 
+	click_border_start.Cut()
+	click_border_end.Cut()
 	storage_start.overlays.Cut()
 
 	var/matrix/M = matrix()
@@ -257,7 +261,7 @@
 	storage_continue.transform = M
 
 	storage_start.screen_loc = "4:16,2:16"
-	storage_continue.screen_loc = "4:[storage_cap_width+(storage_width-storage_cap_width*2)/2+2],2:16"
+	storage_continue.screen_loc = "4:[round(storage_cap_width+(storage_width-storage_cap_width*2)/2+2)],2:16"
 	storage_end.screen_loc = "4:[19+storage_width-storage_cap_width],2:16"
 
 	var/startpoint = 0
@@ -267,11 +271,14 @@
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/storage.max_storage_space
 
+		click_border_start.Add(startpoint)
+		click_border_end.Add(endpoint)
+
 		var/matrix/M_start = matrix()
 		var/matrix/M_continue = matrix()
 		var/matrix/M_end = matrix()
 		M_start.Translate(startpoint,0)
-		M_continue.Scale((endpoint-startpoint-stored_cap_width*2)/32,1)
+		M_continue.Scale(ceil(endpoint-startpoint-stored_cap_width*2)/32,1)
 		M_continue.Translate(startpoint+stored_cap_width+(endpoint-startpoint-stored_cap_width*2)/2 - 16,0)
 		M_end.Translate(endpoint-stored_cap_width,0)
 		stored_start.transform = M_start
@@ -283,8 +290,7 @@
 
 		O.screen_loc = "4:[round((startpoint+endpoint)/2)+2],2:16"
 		O.maptext = ""
-		//O.hud_layerise()
 		O.layer = ABOVE_HUD_LAYER
-		O.plane = ABOVE_HUD_PLANE
+		O.plane = HUD_PLANE
 
 	closer.screen_loc = "4:[storage_width+19],2:16"

--- a/code/game/objects/items/weapons/storage/storage_ui/storage_ui.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/storage_ui.dm
@@ -1,5 +1,7 @@
 /datum/storage_ui
 	var/obj/item/weapon/storage/storage
+	var/list/click_border_start = new/list() //In slotless storage, stores areas where clicking will refer to the associated item
+	var/list/click_border_end = new/list()
 
 /datum/storage_ui/New(var/storage)
 	src.storage = storage

--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -10,7 +10,7 @@
 	throw_speed = 1
 	throw_range = 7
 	w_class = ITEM_SIZE_LARGE
-	max_storage_space = DEFAULT_LARGEBOX_STORAGE
+	max_storage_space = DEFAULT_BOX_STORAGE + 2 // fits all tools and around 2 extra items
 	origin_tech = "combat=1"
 	attack_verb = list("robusted")
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -97,6 +97,7 @@
 			new /obj/item/device/chameleon(src)
 
 	tag = tagname
+	make_exact_fit()
 
 
 /obj/item/weapon/storage/box/syndie_kit
@@ -145,11 +146,11 @@
 	new /obj/item/clothing/head/helmet/space/syndicate(src)
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/emergency_oxygen/engi(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
 	name = "Chameleon Kit"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
-	storage_slots = 10
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon/atom_init()
 	. = ..()
@@ -163,6 +164,7 @@
 	new /obj/item/clothing/glasses/chameleon(src)
 	new /obj/item/weapon/gun/projectile/chameleon(src)
 	new /obj/item/ammo_box/magazine/chameleon(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/throwing_weapon
 	name = "box (F)"
@@ -173,6 +175,7 @@
 		new /obj/item/weapon/legcuffs/bola/tactical(src)
 	for (var/i in 1 to 5)
 		new /obj/item/weapon/throwing_star(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/cutouts
 	name = "box (G)"
@@ -182,6 +185,7 @@
 	for(var/i = 1 to 3)
 		new /obj/item/cardboard_cutout(src)
 	new /obj/item/toy/crayon/rainbow (src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/rig
 	name = "box (J)"
@@ -191,6 +195,7 @@
 	new /obj/item/clothing/suit/space/rig/syndi(src)
 	new /obj/item/clothing/head/helmet/space/rig/syndi(src)
 	new /obj/item/clothing/shoes/magboots/syndie(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/armor
 	name = "box (K)"
@@ -202,6 +207,7 @@
 		new /obj/item/clothing/head/helmet/syndiassault(src)
 	else
 		new /obj/item/clothing/head/helmet/syndiassault/alternate(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/fake
 	name = "box (B)"
@@ -227,6 +233,7 @@
 	. = ..()
 	for(var/i in 0 to 6)
 		new /obj/item/weapon/poster/contraband(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/merch
 	name = "box (M)"
@@ -237,3 +244,4 @@
 	new /obj/item/clothing/head/soft/red(src)
 	new /obj/item/clothing/suit/syndieshirt(src)
 	new /obj/item/toy/syndicateballoon(src)
+	make_exact_fit()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -225,6 +225,7 @@
 	. = ..()
 	for(var/i in 0 to 6)
 		new /obj/item/weapon/poster/contraband/rev(src)
+	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/posters
 	name = "box (P)"


### PR DESCRIPTION
Размер бинтов и шин увеличен чтобы аптечки были более заполненными
Размер медицинского телепорта уменьшен до маленького
Фикс графического бага в виде пустой полосочки которая иногда появлялась на прямоугольнике предмета
Вместимость тулбоксов уменьшена чтобы нельзя была таскать в нём по два набора инструментов
Кликать именно по самому предмету чтобы достать из рюкзака теперь не обязательно, можно и по прямоугольнику в котором этот предмет находится
Фикс выезжающих за экран предметов (в основном в триторских и нюковских коробках)

надо чейнжлог?