### PR TITLE
Фиксим фаер алярм

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1011,7 +1011,7 @@ FIRE ALARM
 					to_chat(user, "You wire \the [src]!")
 					update_icon()
 
-				else if(istype(W, /obj/item/weapon/crowbar))
+				else if(istype(W, /obj/item/weapon/crowbar) && !user.is_busy())
 					to_chat(user, "You start prying out the circuit.")
 					playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
 					if(do_after(user,20,target = src))


### PR DESCRIPTION
Теперь алярмы можно разбирать со спокойной душой, а не ковырять его 100 раз монтировкой и вытаскивать оттуда по 100 плат и удивляться тому, а нахрена туда столько установили и почему там 99 лишних

Ишью - #183 

:cl:
- bugfix: Из фаер алярма при разборке ломом не выпадает куча плат