### PR TITLE
Синий цвет подсветки для консолей Дозора

### DIFF
--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -11,7 +11,7 @@
 	desc = "Used to access the various cameras on the station."
 	icon_state = "cameras"
 	circuit = /obj/item/weapon/circuitboard/security
-	light_color = "#a91515"
+	light_color = "#00008b"
 	var/obj/machinery/camera/current = null
 	var/last_pic = 1.0
 	var/list/network = list("SS13")

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -4,7 +4,7 @@
 	name = "Prisoner Management"
 	icon = 'icons/obj/computer.dmi'
 	icon_state = "explosive"
-	light_color = "#a91515"
+	light_color = "#00008b"
 	req_access = list(access_armory)
 	circuit = /obj/item/weapon/circuitboard/prisoner
 	var/id = 0.0

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -4,7 +4,7 @@
 	name = "Security Records"
 	desc = "Used to view and edit personnel's security records."
 	icon_state = "security"
-	light_color = "#a91515"
+	light_color = "#00008b"
 	req_one_access = list(access_security, access_forensics_lockers)
 	circuit = /obj/item/weapon/circuitboard/secure_data
 	allowed_checks = ALLOWED_CHECK_NONE

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -54,7 +54,7 @@ var/const/FINGERPRINT_COMPLETE = 6	//This is the output of the stringpercent(pri
 /obj/machinery/computer/forensic_scanning
 	name = "\improper High-Res Forensic Scanning Computer"
 	icon_state = "forensic"
-	light_color = "#a91515"
+	light_color = "#00008b"
 	allowed_checks = ALLOWED_CHECK_NONE
 	var/obj/item/scanning
 	var/temp = ""


### PR DESCRIPTION
fixes #437
Исправлен свет подсветки для консолей Дозора: камеры, охранные записи, консоль криминалиста и консоли заключённых
:cl: Breyn578
 - bugfix:  Консоли Дозора светились красным