### PR TITLE
Небольшие изменения в предметах Синдиката и..

### DIFF
--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -123,7 +123,7 @@
 	uplink_types = list("nuclear")
 	excludefrom_uplinks = list("traitor")
 
-/datum/uplink_item/dangerous/revolver/toy
+/datum/uplink_item/dangerous/revolver_toy
 	name = "TR-7 Revolver"
 	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
 	item = /obj/item/weapon/gun/projectile/revolver/traitor
@@ -224,7 +224,7 @@
 	uplink_types = list("nuclear")
 	excludefrom_uplinks = list("traitor")
 
-/datum/uplink_item/dangerous/sword/toy
+/datum/uplink_item/dangerous/sword_toy
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/weapon/melee/energy/sword/traitor

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -117,8 +117,19 @@
 /datum/uplink_item/dangerous/revolver
 	name = "TR-7 Revolver"
 	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
+	item = /obj/item/weapon/gun/projectile/revolver
+	cost = 8
+	gamemodes = list(/datum/game_mode/nuclear)
+	uplink_types = list("nuclear")
+	excludefrom_uplinks = list("traitor")
+
+/datum/uplink_item/dangerous/revolver/toy
+	name = "TR-7 Revolver"
+	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
 	item = /obj/item/weapon/gun/projectile/revolver/traitor
 	cost = 8
+	uplink_types = list("traitor")
+	excludefrom_uplinks = list("nuclear")
 
 /datum/uplink_item/dangerous/pistol
 	name = "Stechkin Pistol"

--- a/code/datums/uplinks_items.dm
+++ b/code/datums/uplinks_items.dm
@@ -117,7 +117,7 @@
 /datum/uplink_item/dangerous/revolver
 	name = "TR-7 Revolver"
 	desc = "The syndicate revolver is a traditional handgun that fires .357 Magnum cartridges and has 7 chambers."
-	item = /obj/item/weapon/gun/projectile/revolver
+	item = /obj/item/weapon/gun/projectile/revolver/traitor
 	cost = 8
 
 /datum/uplink_item/dangerous/pistol
@@ -209,6 +209,17 @@
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise."
 	item = /obj/item/weapon/melee/energy/sword
 	cost = 7
+	gamemodes = list(/datum/game_mode/nuclear)
+	uplink_types = list("nuclear")
+	excludefrom_uplinks = list("traitor")
+
+/datum/uplink_item/dangerous/sword/toy
+	name = "Energy Sword"
+	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be pocketed when inactive. Activating it produces a loud, distinctive noise."
+	item = /obj/item/weapon/melee/energy/sword/traitor
+	cost = 7
+	uplink_types = list("traitor")
+	excludefrom_uplinks = list("nuclear")
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -73,6 +73,10 @@
 	desc = "Arrrr matey."
 	icon_state = "cutlass0"
 
+/obj/item/weapon/melee/energy/sword/traitor
+	name = "toy sword"
+	desc = "A cheap, plastic replica of an energy sword. Realistic sounds! Ages 8 and up."
+
 /obj/item/weapon/melee/energy/sword/pirate/attackby()
 	return
 

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -106,7 +106,7 @@
 	icon_state = "box_of_doom"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
-	name = "boxed freedom implant (with injector)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom/atom_init()
 	. = ..()
@@ -115,21 +115,21 @@
 	O.update()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress
-	name = "box (C)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress/atom_init()
 	new /obj/item/weapon/implanter/compressed(src)
 	. = ..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	name = "box (E)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive/atom_init()
 	new /obj/item/weapon/implanter/explosive(src)
 	. = ..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	name = "boxed uplink implant (with injector)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink/atom_init()
 	. = ..()
@@ -138,7 +138,7 @@
 	O.update()
 
 /obj/item/weapon/storage/box/syndie_kit/space
-	name = "boxed space suit and helmet"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/space/atom_init()
 	. = ..()
@@ -149,7 +149,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
-	name = "Chameleon Kit"
+	name = "box"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon/atom_init()
@@ -167,7 +167,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/throwing_weapon
-	name = "box (F)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/throwing_weapon/atom_init()
 	. = ..()
@@ -178,7 +178,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/cutouts
-	name = "box (G)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/cutouts/atom_init()
 	. = ..()
@@ -188,7 +188,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/rig
-	name = "box (J)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/rig/atom_init()
 	. = ..()
@@ -198,7 +198,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/armor
-	name = "box (K)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/armor/atom_init()
 	. = ..()
@@ -210,7 +210,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/fake
-	name = "box (B)"
+	name = "box"
 	desc = "This set allows you to forge various documents at the station."
 
 /obj/item/weapon/storage/box/syndie_kit/fake/atom_init()
@@ -219,7 +219,7 @@
 	new /obj/item/weapon/stamp/chameleon(src)
 
 /obj/item/weapon/storage/box/syndie_kit/rev_posters
-	name = "box (PR)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/rev_posters/atom_init()
 	. = ..()
@@ -228,7 +228,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/posters
-	name = "box (P)"
+	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/posters/atom_init()
 	. = ..()
@@ -237,7 +237,7 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/merch
-	name = "box (M)"
+	name = "box"
 	desc = "Box containing some Syndicate merchandise for real agents!"
 
 /obj/item/weapon/storage/box/syndie_kit/merch/atom_init()

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -1,4 +1,5 @@
 /obj/item/weapon/storage/box/syndicate/
+	name = "box"
 
 /obj/item/weapon/storage/box/syndicate/atom_init()
 	. = ..()
@@ -101,12 +102,10 @@
 
 
 /obj/item/weapon/storage/box/syndie_kit
-	name = "box"
 	desc = "A sleek, sturdy box."
 	icon_state = "box_of_doom"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_freedom/atom_init()
 	. = ..()
@@ -115,21 +114,18 @@
 	O.update()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_compress/atom_init()
 	new /obj/item/weapon/implanter/compressed(src)
 	. = ..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_explosive/atom_init()
 	new /obj/item/weapon/implanter/explosive(src)
 	. = ..()
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/imp_uplink/atom_init()
 	. = ..()
@@ -138,7 +134,6 @@
 	O.update()
 
 /obj/item/weapon/storage/box/syndie_kit/space
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/space/atom_init()
 	. = ..()
@@ -149,7 +144,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon
-	name = "box"
 	desc = "Comes with all the clothes you need to impersonate most people.  Acting lessons sold seperately."
 
 /obj/item/weapon/storage/box/syndie_kit/chameleon/atom_init()
@@ -167,7 +161,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/throwing_weapon
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/throwing_weapon/atom_init()
 	. = ..()
@@ -178,7 +171,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/cutouts
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/cutouts/atom_init()
 	. = ..()
@@ -188,7 +180,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/rig
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/rig/atom_init()
 	. = ..()
@@ -198,7 +189,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/armor
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/armor/atom_init()
 	. = ..()
@@ -210,7 +200,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/fake
-	name = "box"
 	desc = "This set allows you to forge various documents at the station."
 
 /obj/item/weapon/storage/box/syndie_kit/fake/atom_init()
@@ -219,7 +208,6 @@
 	new /obj/item/weapon/stamp/chameleon(src)
 
 /obj/item/weapon/storage/box/syndie_kit/rev_posters
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/rev_posters/atom_init()
 	. = ..()
@@ -228,7 +216,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/posters
-	name = "box"
 
 /obj/item/weapon/storage/box/syndie_kit/posters/atom_init()
 	. = ..()
@@ -237,7 +224,6 @@
 	make_exact_fit()
 
 /obj/item/weapon/storage/box/syndie_kit/merch
-	name = "box"
 	desc = "Box containing some Syndicate merchandise for real agents!"
 
 /obj/item/weapon/storage/box/syndie_kit/merch/atom_init()

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -271,7 +271,7 @@
 	for (var/i in 1 to 2)
 		new /obj/item/ammo_box/magazine/c45r(src)
 	new /obj/item/taperoll/police(src)
-	new /obj/item/weapon/gun/projectile/automatic/colt1911(src)
+	new /obj/item/weapon/gun/projectile/automatic/colt1911/detective(src)
 	new /obj/item/clothing/accessory/holster/armpit(src)
 
 /obj/structure/closet/secure_closet/detective/update_icon()

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -389,25 +389,6 @@
 	mag_type = /obj/item/ammo_box/magazine/c45m
 	mag_type2 = /obj/item/ammo_box/magazine/c45r
 
-/obj/item/weapon/gun/projectile/automatic/colt1911/detective
-	desc = "A single-action, semi-automatic, magazine-fed, recoil-operated pistol chambered for the .45 ACP cartridge."
-	name = "\improper Colt M1911"
-	mag_type = /obj/item/ammo_box/magazine/c45m
-	mag_type2 = /obj/item/ammo_box/magazine/c45r
-
-/obj/item/weapon/gun/projectile/automatic/colt1911/detective/verb/rename_gun()
-	set name = "Name Gun"
-	set category = "Object"
-	set desc = "Click to rename your gun."
-
-	var/mob/M = usr
-	var/input = sanitize_safe(input(M,"What do you want to name the gun?"), MAX_NAME_LEN)
-
-	if(src && input && !M.stat && in_range(M,src))
-		name = input
-		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
-		return 1
-
 /obj/item/weapon/gun/projectile/automatic/borg
 	name = "Robot SMG"
 	icon_state = "borg_smg"

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -389,6 +389,25 @@
 	mag_type = /obj/item/ammo_box/magazine/c45m
 	mag_type2 = /obj/item/ammo_box/magazine/c45r
 
+/obj/item/weapon/gun/projectile/automatic/colt1911/detective
+	desc = "A single-action, semi-automatic, magazine-fed, recoil-operated pistol chambered for the .45 ACP cartridge."
+	name = "\improper Colt M1911"
+	mag_type = /obj/item/ammo_box/magazine/c45m
+	mag_type2 = /obj/item/ammo_box/magazine/c45r
+
+/obj/item/weapon/gun/projectile/automatic/colt1911/detective/verb/rename_gun()
+	set name = "Name Gun"
+	set category = "Object"
+	set desc = "Click to rename your gun."
+
+	var/mob/M = usr
+	var/input = sanitize_safe(input(M,"What do you want to name the gun?"), MAX_NAME_LEN)
+
+	if(src && input && !M.stat && in_range(M,src))
+		name = input
+		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
+		return 1
+
 /obj/item/weapon/gun/projectile/automatic/borg
 	name = "Robot SMG"
 	icon_state = "borg_smg"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -221,6 +221,20 @@
 			to_chat(user, "<span class='notice'>There's already a magazine in \the [src].</span>")
 	return 0
 
+/obj/item/weapon/gun/projectile/automatic/colt1911/detective
+
+/obj/item/weapon/gun/projectile/automatic/colt1911/detective/verb/rename_gun()
+	set name = "Name Gun"
+	set category = "Object"
+	set desc = "Click to rename your gun."
+
+	var/mob/M = usr
+	var/input = sanitize_safe(input(M,"What do you want to name the gun?"), MAX_NAME_LEN)
+
+	if(src && input && !M.incapacitated())
+		name = input
+		to_chat(M, "You name the gun [input]. Say hello to your new friend.")
+
 /obj/item/weapon/gun/projectile/sec_pistol
 	name = "\improper pistol"
 	desc = "AT-7 .45 caliber pistol."

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -50,6 +50,10 @@
 	..()
 	to_chat(user, "[get_ammo(0,0)] of those are live rounds.")
 
+/obj/item/weapon/gun/projectile/revolver/traitor
+	desc = "Looks almost like the real thing! Ages 8 and up. Please recycle in an autolathe when you're out of caps!"
+	name = "cap gun"
+
 /obj/item/weapon/gun/projectile/revolver/detective
 	desc = "A cheap Martian knock-off of a Smith & Wesson Model 10. Uses .38-Special rounds."
 	name = "revolver"


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Теперь ВСЕ синдикатовские коробки спавнятся игроку с названием "box"
Так же пошелестил код, и добавил на новый кольт детективу возможно его переименования.(которая была на старом его револьвере)
Револьвер синдиката стал "игрушечным" так же как и есворд. У синдиката есворд прежний.
:cl:
 - balance: Теперь ящики синдиката спавнятся "безымянными"
 - balance: У трейторов теперь "игрушечные" есворд и револьвер
 - tweak: У детектива вернулась возможность давать имя своему оружию.
