### PR TITLE
Фиксим пропавший href в АПЦ

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -819,6 +819,9 @@
 	if(!can_use(usr, 1))
 		return
 
+	else if(href_list["toggleaccess"])
+		locked = !locked
+
 	else if (href_list["lock"])
 		coverlocked = !coverlocked
 


### PR DESCRIPTION
fixed:  #446

Возвращаем каким-то образом пропавший href в апц. ИИ сможет вместе с боргами тыкать на волшебную кнопочку и открывать|закрывать АПЦ для простых смертных не имеющего нужного доступа

:cl:
- bugfix: ИИ и борги могут снова разблокировать АПЦ