### PR TITLE
Meatspike fix

### DIFF
--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -13,7 +13,7 @@
 	if(default_unfasten_wrench(user, I))
 		return
 	else if(!anchored && istype(I, /obj/item/stack/rods))
-		to_chat(user, "<span class='notice'>Wrench it up first!</span>")
+		to_chat(user, "<span class='warning'>Wrench it up first!</span>")
 	else if(anchored && istype(I, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = I
 		if(R.use(4))

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -22,7 +22,7 @@
 			transfer_fingerprints_to(F)
 			qdel(src)
 		else
-			to_chat(user, "\red You need at least four rods to do this.")
+			to_chat(user, "<span class='warning'>You need at least four rods to do this.</span>")
 	else
 		..()
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -4,7 +4,7 @@
 	name = "meatspike frame"
 	icon = 'icons/obj/kitchen.dmi'
 	icon_state = "spikeframe"
-	desc = "The frame of a meat spike."
+	desc = "The frame of a meat spike. Needs some metal rods to be finished"
 	density = TRUE
 	anchored = FALSE
 
@@ -12,6 +12,8 @@
 	add_fingerprint(user)
 	if(default_unfasten_wrench(user, I))
 		return
+	else if(!anchored && istype(I, /obj/item/stack/rods))
+		to_chat(user, "<span class='notice'>Wrench it up first!</span>")
 	else if(anchored && istype(I, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = I
 		if(R.use(4))
@@ -19,6 +21,8 @@
 			var/obj/F = new /obj/structure/kitchenspike(src.loc)
 			transfer_fingerprints_to(F)
 			qdel(src)
+		else
+			to_chat(user, "\red You need at least four rods to do this.")
 	else
 		..()
 


### PR DESCRIPTION
Спасаем малогеев которые не знают что делать с фреймами митспайков. Теперь при попытке закончить митфрейм недостаточным количеством прутьев сообщается, что нужно минимум 4. При попытке закончить митфрейм не прикрученный к полу - говорит сначала его прикрутить. Никому это ненужно. Никто этого не просил. Все просят карту. Но я делаю это. Потому что я так решил. Спасибо за внимание.

:cl:
 - tweak: Мясные крюки теперь сообщают какие условия не позволяют закончить их
 
