### PR TITLE
sodadispenser fix

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -290,7 +290,7 @@
 
 			else
 				to_chat(user, "You change the mode from 'Pizza King' to 'McNano'.")
-				dispensable_reagents -= list("thirteenloko")
+				dispensable_reagents -= list("thirteenloko","grapesoda")
 				hackedcheck = 0
 				return
 


### PR DESCRIPTION
Можно было бесконечно взламывать/чинить раздатчик безалкогольных напитков и получать что-то вроде этого:
![image](https://user-images.githubusercontent.com/29666964/48962800-2b8f3480-ef8e-11e8-82a0-8a946fd42e8c.png)
:cl:
 - bugfix: Раздатчик соды не дублирует grape soda при взломе

