### PR TITLE
Последний фикс ~~пипетки~~ шлюзов.

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -128,7 +128,7 @@ var/list/airlock_overlays = list()
 	return ((!secondsMainPowerLost || !secondsBackupPowerLost) && !(stat & NOPOWER))
 
 /obj/machinery/door/airlock/requiresID()
-	return  !(isWireCut(AIRLOCK_WIRE_IDSCAN) || aiDisabledIdScanner) || !req_access.len
+	return !check_access(null) && !(isWireCut(AIRLOCK_WIRE_IDSCAN) || aiDisabledIdScanner)
 
 /obj/machinery/door/airlock/proc/isAllPowerCut()
 	if(isWireCut(AIRLOCK_WIRE_MAIN_POWER1) || isWireCut(AIRLOCK_WIRE_MAIN_POWER2))

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -157,7 +157,7 @@
 		else
 			close()
 		return
-	else if(density)
+	else if(density && Adjacent(user))
 		do_animate("deny")
 
 
@@ -356,7 +356,7 @@
 
 
 /obj/machinery/door/proc/requiresID()
-	return FALSE
+	return !check_access(null)
 
 /obj/machinery/door/update_nearby_tiles(need_rebuild)
 	. = ..()

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -114,7 +114,6 @@
 	var/mob/M = AM
 	if(!M.restrained())
 		bumpopen(M)
-	return
 
 /obj/machinery/door/window/bumpopen(mob/user)
 	if( operating || !src.density )
@@ -127,7 +126,7 @@
 
 	if(allowed(user))
 		open_and_close()
-	else
+	else if(Adjacent(user)) // Telekinesis be a bitch.
 		do_animate("deny")
 
 /obj/machinery/door/window/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)


### PR DESCRIPTION
Сказочке конец, пофиксил вот что:
- Открывание шлюзов людьми.
- Открывание шлюзов Тихеонами издалека.
- Открывание стеклянных дверей и теми и другими.

И пока результат довольствовал, рантаймов не словил.

Чем отличается от того что сейчас: Тихеоне могут открывать двери издалека, у стеклянных дверок работает доступ, не проигрывается анимация отказа доступа тихеоном которые открывают издалека.

:cl: Luduk
- bugfix: Стеклянные двери работают корректно

<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
