### PR TITLE
Отключено логирование у серверов связи

### DIFF
--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -540,7 +540,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 			if(traffic > 0)
 				totaltraffic += traffic // add current traffic to total traffic
-
+/*
 			//Is this a test signal? Bypass logging
 			if(signal.data["type"] != 4)
 
@@ -585,7 +585,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 				// Give the log a name
 				var/identifier = num2text( rand(-1000,1000) + world.time )
 				log.name = "data packet ([md5(identifier)])"
-
+*/
 			var/can_send = relay_information(signal, "/obj/machinery/telecomms/hub")
 			if(!can_send)
 				relay_information(signal, "/obj/machinery/telecomms/broadcaster")


### PR DESCRIPTION
Так как консоль просмотра логов всё равно бесполезна, то функция сбора логов серверами тоже не имеет смысла, а лишь жрёт ресурсы. 

Пример списка:
:cl:
 - performance: Сервера связи больше не собирают бесполезную информацию
