### PR TITLE
Добавление платы боевого модуля (Только не пиздите, дайте объясню)

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -37,6 +37,32 @@
 
 	return 1
 
+/obj/item/borg/upgrade/combat
+	name = "combat module"
+	desc = "Module for crisis situation, which required installed security module (Use only in red code)."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+
+/obj/item/borg/upgrade/combat/action(mob/living/silicon/robot/R, mob/user)
+	if(..()) return 0
+	if(!istype(R.module, /obj/item/weapon/robot_module/security)) return 0
+	R.uneq_all()
+	R.hands.icon_state = "nomod"
+	var/list/icon = list("Combat Android","Acheron","Kodiak")
+	var/appearance = input(user, "Please, select your appearance", "Combat module status: on", input_default("Combat Android")) in icon
+	switch(appearance)
+		if("Combat Android")
+			R.icon_state = "droid-combat"
+		if("Acheron")
+			R.icon_state = "mechoid-Combat"
+		if("Kodiak")
+			R.icon_state = "kodiak-combat"
+	qdel(R.module)
+	R.module = new /obj/item/weapon/robot_module/combat(src)
+	R.updatename("Combat")
+	R.updateicon()
+	return 1
+
 /obj/item/borg/upgrade/rename
 	name = "robot reclassification board"
 	desc = "Used to rename a cyborg."
@@ -147,7 +173,6 @@
 		R.internals = jet*/
 	//R.icon_state="Miner+j"
 	return 1
-
 
 /obj/item/borg/upgrade/syndicate/
 	name = "illegal equipment module"

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -898,6 +898,15 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_combat
+	name = "Cyborg Upgrade Module (Combat Module)"
+	id = "borg_upgrade_combat"
+	build_type = MECHFAB
+	req_tech = list("materials" = 6, "combat" = 5, "engineering"= 4, "powerstorage"= 5, "bluespace" = 3)
+	build_path = /obj/item/borg/upgrade/combat
+	materials = list(MAT_METAL=80000, MAT_GLASS=60000, MAT_PHORON=20000, MAT_URANIUM=20000 , MAT_DIAMOND=5000 , MAT_GOLD=20000)
+	construction_time = 300
+	category = list("Cyborg Upgrade Modules")
 
 //Misc
 /datum/design/mecha_tracking


### PR DESCRIPTION
<!--
Подробно про оформление ПРов можно прочитать тут: https://github.com/TauCetiStation/TauCetiClassic/wiki/Styling-of-Pull-Requests-for-Dummies
Там же написано про то, как сделать чейнджлог. 

!!!
Если авторство не полностью ваше, вы делаете порт с другого билда - укажите первоисточник изменений!
Для крупных комплексных изменений достаточно будет указать билд(ы)-первоисточник, в остальных случаях можете указать исходный ПР.
!!!

Для копипаста:
Список классификаторов для быстрого копирования: bugfix, rscadd, rscdel, image, sound, spellcheck, tweak, balance, map, performance, experiment.

Пример списка:
:cl:
 - image: Добавлен плакат с изображением статного мужчины с конусом на голове и арбузами вокруг него.
 - image: С плаката чужого в форме горничной убрана цензура.
-->
Да, я понимаю что это может навести много хейта, но почему контент должен лежать без дела?
Получается так, что этот контент не используют, не игроки, не админы.
Я тут я подумал, почему бы не ввести этот модуль, виде платы которую можно получить за прогресс, либо же, через спавн этого же самой платы админами(у которых есть доступ к этим операциям).
Плату нельзя будет просто так получить, понадобится исследования и куча ресурсов. Если же условия выполнены, то пусть игрок получить то за что он старался (все равно у борга есть законы).

:cl: DarkLevel
- rscadd: Добавлена плата позволяющая  переключить охранных боргов в комбат боргов.