### PR TITLE
Forcing vomit with fingers, reagents and punches.

### DIFF
--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -41,15 +41,8 @@ Bonus
 	return
 
 /datum/symptom/vomit/proc/Vomit(mob/living/M)
+	M.vomit()
 
-	M.visible_message("<B>[M]</B> vomits on the floor!")
-
-	M.nutrition -= 20
-	M.adjustToxLoss(-3)
-
-	var/turf/pos = get_turf(M)
-	pos.add_vomit_floor(M)
-	playsound(pos, 'sound/effects/splat.ogg', 50, 1)
 /*
 //////////////////////////////////////
 
@@ -80,9 +73,7 @@ Bonus
 	level = 4
 
 /datum/symptom/vomit/blood/Vomit(mob/living/M)
-
-	M.Stun(1)
-	M.visible_message("<B>[M]</B> vomits on the floor!")
+	M.vomit()
 
 	// They lose blood and health.
 	var/brute_dam = M.getBruteLoss()
@@ -91,4 +82,3 @@ Bonus
 
 	var/turf/simulated/pos = get_turf(M)
 	pos.add_blood_floor(M)
-	playsound(pos, 'sound/effects/splat.ogg', 50, 1)

--- a/code/modules/mining/equipment_locker.dm
+++ b/code/modules/mining/equipment_locker.dm
@@ -492,14 +492,8 @@
 				L.Weaken(3)
 				if(ishuman(L))
 					shake_camera(L, 20, 1)
-					spawn(20)
-						if(L)
-							L.visible_message("<span class='danger'>[L.name] vomits from travelling through the [src.name]!</span>", "<span class='userdanger'>You throw up from travelling through the [src.name]!</span>")
-							L.nutrition -= 20
-							L.adjustToxLoss(-3)
-							var/turf/T = get_turf(L)
-							T.add_vomit_floor(L)
-							playsound(L, 'sound/effects/splat.ogg', 50, 1)
+					INVOKE_ASYNC(L, /mob/living/carbon/human.proc/invoke_vomit)
+
 
 
 /**********************Resonator**********************/

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -600,8 +600,7 @@
 		visible_message("<span class='danger'>[src] heaves violently, expelling a rush of vomit and a wriggling, sluglike creature!</span>")
 		B.chemicals -= 100
 
-		new /obj/effect/decal/cleanable/vomit(get_turf(src))
-		playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+		vomit()
 		new /mob/living/simple_animal/borer(get_turf(src))
 
 	else
@@ -687,3 +686,15 @@
 /mob/living/carbon/proc/crawl_in_blood(obj/effect/decal/cleanable/blood/floor_blood,amount)
 	return
 
+/mob/living/carbon/vomit(punched = FALSE)
+	if(head && (head.flags & HEADCOVERSMOUTH))
+		return FALSE
+
+	. = ..()
+	if(.)
+		if(reagents.total_volume > 0)
+			var/datum/reagents/R = new(10)
+			reagents.trans_to(R, 10)
+			R.reaction(loc)
+		else
+			adjustToxLoss(-10)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -113,7 +113,10 @@
 					O.process()
 				return 1
 			else if(!(M == src && apply_pressure(M, M.zone_sel.selecting)))
-				help_shake_act(M)
+				if(M.zone_sel.selecting == O_MOUTH)
+					M.force_vomit(src)
+				else
+					help_shake_act(M)
 				return 1
 
 		if("grab")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -379,6 +379,12 @@
 					apply_effect(5, WEAKEN, armor)
 					visible_message("<span class='userdanger'>[src] has been knocked down!</span>")
 
+				if(!(damage_flags & (DAM_SHARP|DAM_EDGE)) && prob(I.force + 10)) // A chance to force puke with a blunt hit.
+					for(var/obj/item/weapon/grab/G in grabbed_by)
+						if(G.state >= GRAB_AGGRESSIVE && G.assailant == user)
+							vomit(punched=TRUE)
+							return
+
 				if(bloody)
 					bloody_body(src)
 	return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1189,3 +1189,23 @@
 		to_chat(src, "<span class='notice'>You can taste [english_list(final_taste_list)].</span>")
 		telepathy_hear("can taste", "<span class='notice'>[english_list(final_taste_list)]</span>", src)
 		lasttaste = world.time
+
+/mob/living/proc/vomit(punched = FALSE)
+	if(stat == DEAD && !punched)
+		return FALSE
+
+	Stun(3)
+
+	if(nutrition < 40)
+		visible_message("<span class='warning'>[src] convulses in place, gagging!</span>", "<span class='warning'>You try to throw up, but there is nothing!</span>")
+		return FALSE
+
+	visible_message("<span class='warning'>[src] throws up!","<spawn class='warning'>You throw up!</span>")
+	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+	var/turf/location = loc
+	if(istype(location, /turf/simulated))
+		location.add_vomit_floor(src, getToxLoss() > 0 ? TRUE : FALSE)
+
+	nutrition -= 40
+	return TRUE

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -326,7 +326,14 @@
 						force_down = 0
 						return
 					if(state >= GRAB_AGGRESSIVE)
-						H.apply_pressure(assailant, hit_zone)
+						if(!H.apply_pressure(assailant, hit_zone))
+							if(hit_zone == BP_CHEST)
+								var/chance_to_force_vomit = 30
+								if(H.stat >= UNCONSCIOUS)
+									chance_to_force_vomit += 20
+								user.visible_message("<span class='notice'>[user] squeezes [H], trying to make them puke.</span>")
+								if(prob(chance_to_force_vomit))
+									H.vomit(punched=TRUE)
 					else
 						inspect_organ(affecting, assailant, hit_zone)
 				if("grab")
@@ -367,6 +374,31 @@
 						if (IO.damage >= IO.min_broken_damage)
 							if(affecting.stat != DEAD)
 								to_chat(affecting, "\red You go blind!")
+					else if(state >= GRAB_AGGRESSIVE && hit_zone == BP_CHEST)
+						var/chance_to_force_vomit = 30
+
+						if(ishuman(user))
+							var/mob/living/carbon/human/H_user = user
+							var/datum/unarmed_attack/attack = H_user.species.unarmed
+
+							var/damage = rand(1, 5)
+							damage += attack.damage
+
+							var/obj/item/organ/external/BP = H.bodyparts_by_name[ran_zone(H_user.zone_sel.selecting)]
+							var/armor_block = H.run_armor_check(BP, "melee")
+
+							if(attack.damage_flags() & (DAM_SHARP|DAM_EDGE))
+								chance_to_force_vomit = 0
+							else
+								chance_to_force_vomit += attack.damage
+							H.apply_damage(damage, BRUTE, BP, armor_block, attack.damage_flags())
+						else
+							H.adjustBruteLoss(3)
+
+						user.visible_message("<span class='warning'>[user] punches [H] in the gut, trying to make them puke.</span>")
+						if(prob(chance_to_force_vomit))
+							H.vomit(punched=TRUE)
+
 //					else if(hit_zone != BP_HEAD)
 //						if(state < GRAB_NECK)
 //							assailant << "<span class='warning'>You require a better grab to do this.</span>"

--- a/code/modules/organs/organ_internal.dm
+++ b/code/modules/organs/organ_internal.dm
@@ -208,7 +208,7 @@
 			to_chat(owner, "\red Your skin itches.")
 	if (germ_level > INFECTION_LEVEL_TWO)
 		if(prob(1))
-			INVOKE_ASYNC(owner, /mob/living/carbon/human.proc/vomit)
+			INVOKE_ASYNC(owner, /mob/living/carbon/human.proc/invoke_vomit)
 
 	if(owner.life_tick % process_accuracy == 0)
 		if(src.damage < 0)

--- a/code/modules/reagents/chemistry/reagents/medical_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medical_reagents.dm
@@ -255,6 +255,23 @@
 	if(M.getToxLoss() && prob(80))
 		M.adjustToxLoss(-1 * REM)
 
+/datum/reagent/thermopsis
+	name = "Thermopsis"
+	id = "thermopsis"
+	description = "Irritates stomach receptors, that leads to reflex rise of vomiting."
+	reagent_state = LIQUID
+	color = "#a0a000"
+	taste_message = "vomit"
+	restrict_species = list(IPC, DIONA)
+	data = 1
+
+/datum/reagent/thermopsis/on_general_digest(mob/living/M)
+	..()
+	data++
+	if(data > 10)
+		M.vomit()
+		data -= rand(0, 10)
+
 /datum/reagent/anti_toxin
 	name = "Anti-Toxin (Dylovene)"
 	id = "anti_toxin"

--- a/code/modules/reagents/chemistry/recipes/medicines.dm
+++ b/code/modules/reagents/chemistry/recipes/medicines.dm
@@ -12,6 +12,13 @@
 			required_reagents = list("oxygen" = 1, "carbon" = 1, "sugar" = 1)
 			result_amount = 3
 
+/datum/chemical_reaction/thermopsis
+	name = "Thermopsis"
+	id = "thermopsis"
+	result = "thermopsis"
+	required_reagents = list("anti_toxin" = 1, "sugar" = 1, "carbon" = 1)
+	result_amount = 3
+
 /datum/chemical_reaction/anti_toxin
 			name = "Anti-Toxin (Dylovene)"
 			id = "anti_toxin"


### PR DESCRIPTION
Небольшая переделка рвоты, если у человек в желудке что-то есть(реагенты) - он их срыгнёт на пол, а если нету - у него будут уменьшаться токсины каждый раз на 10.

Заставить кого-то рыгать можно взяв их во второй граб, и ударив в живот(или на хелп, но с меньшим шансом).

Удары во втором грабе тупыми(!) предметами с большим шансом чем руки будут заставлять игрока блевать.

Добавлен реагент который заставляет блевать.

Добавлен уникальный функционал засовывания двух пальцев в рот чтобы блевать.

![2019-07-22_22-50-13](https://user-images.githubusercontent.com/17705613/61660707-2deb8f00-acd3-11e9-99f1-0cbc796b0bfa.gif)

:cl: Luduk
- rscadd: Если кликнуть кукле на рот хелпом - вы засуните ей два пальца в рот, и заставите блевать.
- rscadd: Если во втором грабе бить тупыми предметами(или кликать хелпом) - можно заставить куклу блевать.
- rscadd: Термопсис - реагент заставляющий людей блевать.
